### PR TITLE
Spirit Tree Improvements

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/cache/strategy/farming/SpiritTreeUpdateStrategy.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/cache/strategy/farming/SpiritTreeUpdateStrategy.java
@@ -39,6 +39,7 @@ public class SpiritTreeUpdateStrategy implements CacheUpdateStrategy<SpiritTree,
     
     // Spirit tree object IDs for game object detection
     private static final List<Integer> SPIRIT_TREE_OBJECT_IDS = Arrays.asList(
+		ObjectID.FARMING_SPIRIT_TREE_PATCH_5, // Object ID found in farming guild fully grown spirit tree patch
         ObjectID.SPIRIT_TREE_FULLYGROWN,  // Standard spirit spiritTree id when fully grown  and available for travel -> healty )         
         ObjectID.SPIRITTREE_PRIF, // Prifddinas spirit tree  
         ObjectID.POG_SPIRIT_TREE_ALIVE_STATIC,  // Poison Waste spirit tree
@@ -201,9 +202,10 @@ public class SpiritTreeUpdateStrategy implements CacheUpdateStrategy<SpiritTree,
                 return; // Can't determine player location
             }
             
-            // Only update if player is near a spirit tree (within 10 tiles)
-            boolean nearSpiritTree = SpiritTree.getFarmableSpirtTrees().stream()
-                .anyMatch(spiritTree -> playerLocation.distanceTo(spiritTree.getLocation()) <= 10);
+            // Only update if player is near a spirit tree (within region)
+			boolean nearSpiritTree = SpiritTree.getFarmableSpirtTrees().stream()
+				.anyMatch(spiritTree -> Arrays.stream(spiritTree.getRegionIds())
+					.anyMatch(regionId -> regionId != -1 && regionId == playerLocation.getRegionID()));
             
             if (!nearSpiritTree) {
                 log.trace("Player not near any spirit tree patches, skipping varbit update");

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/farming/SpiritTree.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/farming/SpiritTree.java
@@ -41,6 +41,7 @@ public enum SpiritTree {
             0,
             -1,
             ObjectID.ENT, // Spirit Tree object ID i dont know why but it the id for "ENT" in tree gnome village
+			new int[] { -1 },
             "1: Tree Gnome Village"
     ),
 
@@ -52,6 +53,7 @@ public enum SpiritTree {
             0,
             -1,
             ObjectID.STRONGHOLD_ENT, // Spirit Tree object ID
+			new int[] { -1 },
             "2: Gnome Stronghold"
     ),
 
@@ -62,7 +64,8 @@ public enum SpiritTree {
             List.of(Quest.TREE_GNOME_VILLAGE, Quest.THE_GRAND_TREE),
             0,
             -1,
-            ObjectID.SPIRITTREE_SMALL, // Spirit Tree object ID  
+            ObjectID.SPIRITTREE_SMALL, // Spirit Tree object ID
+			new int[] { -1 },
             "3: Battlefield of Khazard"
     ),
 
@@ -74,6 +77,7 @@ public enum SpiritTree {
             0,
             -1,
             ObjectID.SPIRITTREE_SMALL, // Spirit Tree object ID
+			new int[] { -1 },
             "4: Grand Exchange"
     ),
 
@@ -85,6 +89,7 @@ public enum SpiritTree {
             0,
             -1,
             ObjectID.SPIRITTREE_SMALL, // Spirit Tree object ID
+			new int[] { -1 },
             "5: Feldip Hills"
     ),
 
@@ -96,6 +101,7 @@ public enum SpiritTree {
             0,
             -1,
             ObjectID.SPIRITTREE_PRIF, // Prifddinas spirit tree
+			new int[] { -1 },
             "6: Prifddinas"
     ),
 
@@ -107,6 +113,7 @@ public enum SpiritTree {
             0,
             -1,
             ObjectID.POG_SPIRIT_TREE_ALIVE_STATIC, // Poison Waste spirit tree
+			new int[] { -1 },
             "D: Poison Waste"
     ),
 
@@ -119,6 +126,7 @@ public enum SpiritTree {
             83,
             VarbitID.FARMING_TRANSMIT_A, // Port Sarim uses varbit 4771
             ObjectID.SPIRIT_TREE_FULLYGROWN, // Standard spirit patch id when fully grown  and available for travel -> healty , for states between there are other ids
+			new int[] {12082, 12083},
             "7: Port Sarim"
     ),
 
@@ -130,6 +138,7 @@ public enum SpiritTree {
             83,
             VarbitID.FARMING_TRANSMIT_B, // Etceteria uses varbit 4772
             ObjectID.SPIRIT_TREE_FULLYGROWN, // Standard spirit patch id when fully grown  and available for travel -> healty , for states between there are other ids
+			new int[] {10300},
             "8: Etceteria"
     ),
 
@@ -141,6 +150,7 @@ public enum SpiritTree {
             83,
             VarbitID.FARMING_TRANSMIT_B, // Brimhaven spirit tree patch
             ObjectID.SPIRIT_TREE_FULLYGROWN, // Standard spirit patch id when fully grown  and available for travel -> healty , for states between there are other ids
+			new int[] {11058, 11057},
             "9: Brimhaven"
     ),
 
@@ -152,6 +162,7 @@ public enum SpiritTree {
             83,
             VarbitID.FARMING_TRANSMIT_F, // Hosidius spirit tree patch
             ObjectID.SPIRIT_TREE_FULLYGROWN, // Standard spirit patch id when fully grown  and available for travel -> healty , for states between there are other ids
+			new int[] {6967, 6711},
             "A: Hosidius"
     ),
 
@@ -163,6 +174,7 @@ public enum SpiritTree {
             85, // Requires 85 Farming for the Farming Guild
             VarbitID.FARMING_TRANSMIT_A, // Farming Guild spirit tree patch
             ObjectID.SPIRIT_TREE_FULLYGROWN, // Standard spirit patch id when fully grown  and available for travel -> healty , for states between there are other ids
+			new int[] {4922, 5177, 5178, 5179, 4921, 4923, 4665, 4666, 4667},
             "B: Farming Guild"
     );
       /**
@@ -184,6 +196,7 @@ public enum SpiritTree {
     private final int requiredFarmingLevel;
     private final int varbitId; // -1 for built-in trees
     private final int objectId;
+	private final int[] regionIds; // -1 for built-in trees
     private final String adventureLogDisplayName;
 
     /**

--- a/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/spirit_trees.tsv
+++ b/runelite-client/src/main/resources/net/runelite/client/plugins/microbot/shortestpath/spirit_trees.tsv
@@ -1,4 +1,4 @@
-# Origin	Destination	menuOption menuTarget objectID	Skills	Quests	Duration	Display info	Varbits
+# Origin	Destination	menuOption menuTarget objectID	Skills	Quests	Varbits	Duration	Display info
 # Tree Gnome Village							
 2543 3167 0		Travel;Spirit Tree;1293		Tree Gnome Village			
 2544 3167 0		Travel;Spirit Tree;1293		Tree Gnome Village			
@@ -66,72 +66,72 @@
 3273 6125 0		Travel;Spirit Tree;37329		Tree Gnome Village;The Grand Tree;Song of the Elves			
 3273 6124 0		Travel;Spirit Tree;37329		Tree Gnome Village;The Grand Tree;Song of the Elves			
 # Port Sarim							
-3058 3257 0		Travel;Spirit Tree;8355	83 Farming	Tree Gnome Village;The Grand Tree			4771=20;4772=20
-3058 3258 0		Travel;Spirit Tree;8355	83 Farming	Tree Gnome Village;The Grand Tree			4771=20;4772=20
-3058 3259 0		Travel;Spirit Tree;8355	83 Farming	Tree Gnome Village;The Grand Tree			4771=20;4772=20
-3059 3260 0		Travel;Spirit Tree;8355	83 Farming	Tree Gnome Village;The Grand Tree			4771=20;4772=20
-3060 3260 0		Travel;Spirit Tree;8355	83 Farming	Tree Gnome Village;The Grand Tree			4771=20;4772=20
-3061 3260 0		Travel;Spirit Tree;8355	83 Farming	Tree Gnome Village;The Grand Tree			4771=20;4772=20
-3062 3259 0		Travel;Spirit Tree;8355	83 Farming	Tree Gnome Village;The Grand Tree			4771=20;4772=20
-3062 3258 0		Travel;Spirit Tree;8355	83 Farming	Tree Gnome Village;The Grand Tree			4771=20;4772=20
-3062 3257 0		Travel;Spirit Tree;8355	83 Farming	Tree Gnome Village;The Grand Tree			4771=20;4772=20
-3061 3256 0		Travel;Spirit Tree;8355	83 Farming	Tree Gnome Village;The Grand Tree			4771=20;4772=20
-3060 3256 0		Travel;Spirit Tree;8355	83 Farming	Tree Gnome Village;The Grand Tree			4771=20;4772=20
-3059 3256 0		Travel;Spirit Tree;8355	83 Farming	Tree Gnome Village;The Grand Tree			4771=20;4772=20
+3058 3257 0		Travel;Spirit Tree;8355		Tree Gnome Village;The Grand Tree
+3058 3258 0		Travel;Spirit Tree;8355		Tree Gnome Village;The Grand Tree
+3058 3259 0		Travel;Spirit Tree;8355		Tree Gnome Village;The Grand Tree
+3059 3260 0		Travel;Spirit Tree;8355		Tree Gnome Village;The Grand Tree
+3060 3260 0		Travel;Spirit Tree;8355		Tree Gnome Village;The Grand Tree
+3061 3260 0		Travel;Spirit Tree;8355		Tree Gnome Village;The Grand Tree
+3062 3259 0		Travel;Spirit Tree;8355		Tree Gnome Village;The Grand Tree
+3062 3258 0		Travel;Spirit Tree;8355		Tree Gnome Village;The Grand Tree
+3062 3257 0		Travel;Spirit Tree;8355		Tree Gnome Village;The Grand Tree
+3061 3256 0		Travel;Spirit Tree;8355		Tree Gnome Village;The Grand Tree
+3060 3256 0		Travel;Spirit Tree;8355		Tree Gnome Village;The Grand Tree
+3059 3256 0		Travel;Spirit Tree;8355		Tree Gnome Village;The Grand Tree
 # Etceteria							
-2611 3857 0		Travel;Spirit Tree;8355	83 Farming	Tree Gnome Village;The Grand Tree			4771=20;4772=20
-2611 3858 0		Travel;Spirit Tree;8355	83 Farming	Tree Gnome Village;The Grand Tree			4771=20;4772=20
-2611 3859 0		Travel;Spirit Tree;8355	83 Farming	Tree Gnome Village;The Grand Tree			4771=20;4772=20
-2612 3860 0		Travel;Spirit Tree;8355	83 Farming	Tree Gnome Village;The Grand Tree			4771=20;4772=20
-2613 3860 0		Travel;Spirit Tree;8355	83 Farming	Tree Gnome Village;The Grand Tree			4771=20;4772=20
-2614 3860 0		Travel;Spirit Tree;8355	83 Farming	Tree Gnome Village;The Grand Tree			4771=20;4772=20
-2615 3859 0		Travel;Spirit Tree;8355	83 Farming	Tree Gnome Village;The Grand Tree			4771=20;4772=20
-2615 3858 0		Travel;Spirit Tree;8355	83 Farming	Tree Gnome Village;The Grand Tree			4771=20;4772=20
-2615 3857 0		Travel;Spirit Tree;8355	83 Farming	Tree Gnome Village;The Grand Tree			4771=20;4772=20
-2614 3856 0		Travel;Spirit Tree;8355	83 Farming	Tree Gnome Village;The Grand Tree			4771=20;4772=20
-2613 3856 0		Travel;Spirit Tree;8355	83 Farming	Tree Gnome Village;The Grand Tree			4771=20;4772=20
-2612 3856 0		Travel;Spirit Tree;8355	83 Farming	Tree Gnome Village;The Grand Tree			4771=20;4772=20
+2611 3857 0		Travel;Spirit Tree;8355		Tree Gnome Village;The Grand Tree
+2611 3858 0		Travel;Spirit Tree;8355		Tree Gnome Village;The Grand Tree
+2611 3859 0		Travel;Spirit Tree;8355		Tree Gnome Village;The Grand Tree
+2612 3860 0		Travel;Spirit Tree;8355		Tree Gnome Village;The Grand Tree
+2613 3860 0		Travel;Spirit Tree;8355		Tree Gnome Village;The Grand Tree
+2614 3860 0		Travel;Spirit Tree;8355		Tree Gnome Village;The Grand Tree
+2615 3859 0		Travel;Spirit Tree;8355		Tree Gnome Village;The Grand Tree
+2615 3858 0		Travel;Spirit Tree;8355		Tree Gnome Village;The Grand Tree
+2615 3857 0		Travel;Spirit Tree;8355		Tree Gnome Village;The Grand Tree
+2614 3856 0		Travel;Spirit Tree;8355		Tree Gnome Village;The Grand Tree
+2613 3856 0		Travel;Spirit Tree;8355		Tree Gnome Village;The Grand Tree
+2612 3856 0		Travel;Spirit Tree;8355		Tree Gnome Village;The Grand Tree
 # Brimhaven							
-2800 3202 0		Travel;Spirit Tree;8355	83 Farming	Tree Gnome Village;The Grand Tree			4771=20;4772=20
-2800 3203 0		Travel;Spirit Tree;8355	83 Farming	Tree Gnome Village;The Grand Tree			4771=20;4772=20
-2800 3204 0		Travel;Spirit Tree;8355	83 Farming	Tree Gnome Village;The Grand Tree			4771=20;4772=20
-2801 3205 0		Travel;Spirit Tree;8355	83 Farming	Tree Gnome Village;The Grand Tree			4771=20;4772=20
-2802 3205 0		Travel;Spirit Tree;8355	83 Farming	Tree Gnome Village;The Grand Tree			4771=20;4772=20
-2803 3205 0		Travel;Spirit Tree;8355	83 Farming	Tree Gnome Village;The Grand Tree			4771=20;4772=20
-2804 3204 0		Travel;Spirit Tree;8355	83 Farming	Tree Gnome Village;The Grand Tree			4771=20;4772=20
-2804 3203 0		Travel;Spirit Tree;8355	83 Farming	Tree Gnome Village;The Grand Tree			4771=20;4772=20
-2804 3202 0		Travel;Spirit Tree;8355	83 Farming	Tree Gnome Village;The Grand Tree			4771=20;4772=20
-2803 3201 0		Travel;Spirit Tree;8355	83 Farming	Tree Gnome Village;The Grand Tree			4771=20;4772=20
-2802 3201 0		Travel;Spirit Tree;8355	83 Farming	Tree Gnome Village;The Grand Tree			4771=20;4772=20
-2801 3201 0		Travel;Spirit Tree;8355	83 Farming	Tree Gnome Village;The Grand Tree			4771=20;4772=20
+2800 3202 0		Travel;Spirit Tree;8355		Tree Gnome Village;The Grand Tree
+2800 3203 0		Travel;Spirit Tree;8355		Tree Gnome Village;The Grand Tree
+2800 3204 0		Travel;Spirit Tree;8355		Tree Gnome Village;The Grand Tree
+2801 3205 0		Travel;Spirit Tree;8355		Tree Gnome Village;The Grand Tree
+2802 3205 0		Travel;Spirit Tree;8355		Tree Gnome Village;The Grand Tree
+2803 3205 0		Travel;Spirit Tree;8355		Tree Gnome Village;The Grand Tree
+2804 3204 0		Travel;Spirit Tree;8355		Tree Gnome Village;The Grand Tree
+2804 3203 0		Travel;Spirit Tree;8355		Tree Gnome Village;The Grand Tree
+2804 3202 0		Travel;Spirit Tree;8355		Tree Gnome Village;The Grand Tree
+2803 3201 0		Travel;Spirit Tree;8355		Tree Gnome Village;The Grand Tree
+2802 3201 0		Travel;Spirit Tree;8355		Tree Gnome Village;The Grand Tree
+2801 3201 0		Travel;Spirit Tree;8355		Tree Gnome Village;The Grand Tree
 # Hosidius							
-1691 3541 0		Travel;Spirit Tree;8355	83 Farming	Tree Gnome Village;The Grand Tree			4771=20;4772=20
-1691 3542 0		Travel;Spirit Tree;8355	83 Farming	Tree Gnome Village;The Grand Tree			4771=20;4772=20
-1691 3543 0		Travel;Spirit Tree;8355	83 Farming	Tree Gnome Village;The Grand Tree			4771=20;4772=20
-1692 3544 0		Travel;Spirit Tree;8355	83 Farming	Tree Gnome Village;The Grand Tree			4771=20;4772=20
-1693 3544 0		Travel;Spirit Tree;8355	83 Farming	Tree Gnome Village;The Grand Tree			4771=20;4772=20
-1694 3544 0		Travel;Spirit Tree;8355	83 Farming	Tree Gnome Village;The Grand Tree			4771=20;4772=20
-1695 3543 0		Travel;Spirit Tree;8355	83 Farming	Tree Gnome Village;The Grand Tree			4771=20;4772=20
-1695 3542 0		Travel;Spirit Tree;8355	83 Farming	Tree Gnome Village;The Grand Tree			4771=20;4772=20
-1695 3541 0		Travel;Spirit Tree;8355	83 Farming	Tree Gnome Village;The Grand Tree			4771=20;4772=20
-1694 3540 0		Travel;Spirit Tree;8355	83 Farming	Tree Gnome Village;The Grand Tree			4771=20;4772=20
-1693 3540 0		Travel;Spirit Tree;8355	83 Farming	Tree Gnome Village;The Grand Tree			4771=20;4772=20
-1692 3540 0		Travel;Spirit Tree;8355	83 Farming	Tree Gnome Village;The Grand Tree			4771=20;4772=20
+1691 3541 0		Travel;Spirit Tree;8355		Tree Gnome Village;The Grand Tree
+1691 3542 0		Travel;Spirit Tree;8355		Tree Gnome Village;The Grand Tree
+1691 3543 0		Travel;Spirit Tree;8355		Tree Gnome Village;The Grand Tree
+1692 3544 0		Travel;Spirit Tree;8355		Tree Gnome Village;The Grand Tree
+1693 3544 0		Travel;Spirit Tree;8355		Tree Gnome Village;The Grand Tree
+1694 3544 0		Travel;Spirit Tree;8355		Tree Gnome Village;The Grand Tree
+1695 3543 0		Travel;Spirit Tree;8355		Tree Gnome Village;The Grand Tree
+1695 3542 0		Travel;Spirit Tree;8355		Tree Gnome Village;The Grand Tree
+1695 3541 0		Travel;Spirit Tree;8355		Tree Gnome Village;The Grand Tree
+1694 3540 0		Travel;Spirit Tree;8355		Tree Gnome Village;The Grand Tree
+1693 3540 0		Travel;Spirit Tree;8355		Tree Gnome Village;The Grand Tree
+1692 3540 0		Travel;Spirit Tree;8355		Tree Gnome Village;The Grand Tree
 # Farming Guild							
-1251 3749 0		Travel;Spirit Tree;8355	85 Farming	Tree Gnome Village;The Grand Tree			4771=20;4772=20
-1251 3750 0		Travel;Spirit Tree;8355	85 Farming	Tree Gnome Village;The Grand Tree			4771=20;4772=20
-1251 3751 0		Travel;Spirit Tree;8355	85 Farming	Tree Gnome Village;The Grand Tree			4771=20;4772=20
-1252 3752 0		Travel;Spirit Tree;8355	85 Farming	Tree Gnome Village;The Grand Tree			4771=20;4772=20
-1253 3752 0		Travel;Spirit Tree;8355	85 Farming	Tree Gnome Village;The Grand Tree			4771=20;4772=20
-1254 3752 0		Travel;Spirit Tree;8355	85 Farming	Tree Gnome Village;The Grand Tree			4771=20;4772=20
-1255 3751 0		Travel;Spirit Tree;8355	85 Farming	Tree Gnome Village;The Grand Tree			4771=20;4772=20
-1255 3750 0		Travel;Spirit Tree;8355	85 Farming	Tree Gnome Village;The Grand Tree			4771=20;4772=20
-1255 3749 0		Travel;Spirit Tree;8355	85 Farming	Tree Gnome Village;The Grand Tree			4771=20;4772=20
-1254 3748 0		Travel;Spirit Tree;8355	85 Farming	Tree Gnome Village;The Grand Tree			4771=20;4772=20
-1253 3748 0		Travel;Spirit Tree;8355	85 Farming	Tree Gnome Village;The Grand Tree			4771=20;4772=20
-1252 3748 0		Travel;Spirit Tree;8355	85 Farming	Tree Gnome Village;The Grand Tree			4771=20;4772=20
+1251 3749 0		Travel;Spirit Tree;33733		Tree Gnome Village;The Grand Tree
+1251 3750 0		Travel;Spirit Tree;33733		Tree Gnome Village;The Grand Tree
+1251 3751 0		Travel;Spirit Tree;33733		Tree Gnome Village;The Grand Tree
+1252 3752 0		Travel;Spirit Tree;33733		Tree Gnome Village;The Grand Tree
+1253 3752 0		Travel;Spirit Tree;33733		Tree Gnome Village;The Grand Tree
+1254 3752 0		Travel;Spirit Tree;33733		Tree Gnome Village;The Grand Tree
+1255 3751 0		Travel;Spirit Tree;33733		Tree Gnome Village;The Grand Tree
+1255 3750 0		Travel;Spirit Tree;33733		Tree Gnome Village;The Grand Tree
+1255 3749 0		Travel;Spirit Tree;33733		Tree Gnome Village;The Grand Tree
+1254 3748 0		Travel;Spirit Tree;33733		Tree Gnome Village;The Grand Tree
+1253 3748 0		Travel;Spirit Tree;33733		Tree Gnome Village;The Grand Tree
+1252 3748 0		Travel;Spirit Tree;33733		Tree Gnome Village;The Grand Tree
 # Player-owned house							
-#		Travel;Spirit Tree;29227	75 Construction;83 Farming				
+#		Travel;Spirit Tree;29227
 # Poison Waste							
 2337 3110 0		Travel;Spirit Tree;49595		The Path of Glouphrie			
 2337 3111 0		Travel;Spirit Tree;49595		The Path of Glouphrie			
@@ -146,28 +146,28 @@
 2339 3109 0		Travel;Spirit Tree;49595		The Path of Glouphrie			
 2340 3109 0		Travel;Spirit Tree;49595		The Path of Glouphrie			
 # Tree Gnome Village							
-	2542 3170 0			Tree Gnome Village	2	1: Tree Gnome Village	
+	2542 3170 0			Tree Gnome Village		2	1: Tree Gnome Village
 # Gnome Stronghold							
-	2461 3444 0			The Grand Tree	2	2: Gnome Stronghold	
+	2461 3444 0			The Grand Tree		2	2: Gnome Stronghold
 # Battlefield of Khazard							
-	2555 3259 0			Tree Gnome Village;The Grand Tree	2	3: Battlefield of Khazard	
+	2555 3259 0			Tree Gnome Village;The Grand Tree		2	3: Battlefield of Khazard
 # Grand Exchange							
-	3185 3508 0			Tree Gnome Village;The Grand Tree	2	4: Grand Exchange	
+	3185 3508 0			Tree Gnome Village;The Grand Tree		2	4: Grand Exchange
 # Feldip Hills							
-	2488 2850 0			Tree Gnome Village;The Grand Tree	2	5: Feldip Hills	
+	2488 2850 0			Tree Gnome Village;The Grand Tree		2	5: Feldip Hills
 # Prifddinas							
-	3274 6123 0			Tree Gnome Village;The Grand Tree;Song of the Elves	2	6: Prifddinas	
+	3274 6123 0			Tree Gnome Village;The Grand Tree;Song of the Elves		2	6: Prifddinas
 # Port Sarim							
-	3058 3257 0		83 Farming	Tree Gnome Village;The Grand Tree	2	7: Port Sarim	4771=20;4772=20
+	3058 3257 0			Tree Gnome Village;The Grand Tree		2	7: Port Sarim
 # Etceteria							
-	2613 3855 0		83 Farming	Tree Gnome Village;The Grand Tree	2	8: Etceteria	4771=20;4772=20
+	2613 3855 0			Tree Gnome Village;The Grand Tree		2	8: Etceteria
 # Brimhaven							
-	2800 3203 0		83 Farming	Tree Gnome Village;The Grand Tree	2	9: Brimhaven	4771=20;4772=20
+	2800 3203 0			Tree Gnome Village;The Grand Tree		2	9: Brimhaven
 # Hosidius							
-	1693 3540 0		83 Farming	Tree Gnome Village;The Grand Tree	2	A: Hosidius	4771=20;4772=20
+	1693 3540 0			Tree Gnome Village;The Grand Tree		2	A: Hosidius
 # Farming Guild							
-	1251 3750 0		85 Farming	Tree Gnome Village;The Grand Tree	2	B: Farming Guild	4771=20;4772=20
+	1251 3750 0			Tree Gnome Village;The Grand Tree		2	B: Farming Guild
 # Player-owned house							
-#			75 Construction;83 Farming	Tree Gnome Village;The Grand Tree	2	C: Your house	
+#				Tree Gnome Village;The Grand Tree		2	C: Your house
 # Poison Waste							
-	2339 3109 0			Tree Gnome Village;The Grand Tree;The Path of Glouphrie	2	D: Poison Waste	
+	2339 3109 0			Tree Gnome Village;The Grand Tree;The Path of Glouphrie		2	D: Poison Waste


### PR DESCRIPTION
### Fixes
- Improve `updateFarmingStatesFromVarbits` in `SpiritTreeUpdateStrategy.java` by adding respective region ids within `SpiritTree` enum. this provides a more accurate definition of where these varbits will change.
- Improve `isSpiritTreeTransportAvailable` in `Rs2SpiritTreeCache.java` by changing `isOriginAvailable(transport.getOrigin())` -> `isOriginAvailable(transport.getOrigin()) & isDestinationAvailable(transport.getDestination())`


### Chores
- Replace some instances where lambda expressions could be used
- Remove hard requirements from `spirit_trees.tsv` in-order to rely off data within caching system